### PR TITLE
fix: 業務割当の業務種別選択で入力済みフィールドが上書きされる問題を修正

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -141,21 +141,21 @@
 
 **Context:** `/plan-eng-review` (2026-04-10) の Step 0 で発見。duty-assignment-page-client.tsx の Props 型定義も dutyTypeOptions のインライン型を DutyTypeOption[] に置き換えられる。
 
-## UX改善: 編集時のDutyType変更でdefault値が上書きされる問題
+## UX改善: シフトフォームのシフトコード変更でdefault値が上書きされる問題
 
-**What:** DutyAssignmentForm の編集モードで業務種別を変更すると、手入力済みの startTime/endTime/note が defaultXxx 値で無言で上書きされる。title のみ「新規作成時のみ自動補完」に修正済みだが、他のdefault値も同様の対応が必要。
+**What:** `components/shifts/shift-form.tsx` の `handleSelectChange` (line 195-226) が、シフトコード（プリセット）選択時に `startTime` / `endTime` / `lunchBreakStart` / `lunchBreakEnd` / `isHoliday` を無条件で上書きする。ユーザーが手入力した時刻や休日フラグがプリセット選択で失われる可能性がある。
 
-**Why:** ユーザーが手で修正した時間や備考が、業務種別を変更しただけで消える。特に時間帯の修正は頻繁に行われるため、影響が大きい。Codex adversarial review (2026-04-11) で発見。
+**Why:** DutyAssignmentForm で同種のバグを修正済み (2026-04-20)。shift-form も同じパターンで同じ問題を抱えている。ユーザーが明示的に入力した値を業務種別/プリセットのデフォルトで上書きすべきではない。
 
-**Pros:** 編集時のデータ消失リスクがなくなる。ユーザーの入力が尊重される。
+**Pros:** UX の一貫性（業務割当とシフトで同じ挙動）。入力データの消失リスクを削減。
 
-**Cons:** handleDutyTypeChange の条件分岐が増える（新規/編集で動作が異なる）。
+**Cons:** shift-form は ref ベースで time inputs を管理しており、duty-assignment-form (state ベース) とは実装パターンが異なる。ref.current.value で空判定するため条件分岐のスタイルが少し異なる。
 
 **Effort:** S (human) → XS (CC+gstack) | **Priority:** P2 | **Risk:** Low
 
-**Depends on:** タイトルカラム追加の実装完了
+**Depends on:** なし（独立修正）
 
-**Context:** duty-assignment-form.tsx:115-124 の handleDutyTypeChange が対象。現在は新規・編集問わず全 default 値を上書きする。title は今回のPRで「新規のみ」に修正されるが、startTime/endTime/note/reducesCapacity も同じパターンにすべき。
+**Context:** DutyAssignmentForm 側は `handleDutyTypeChange` を「空フィールドのみデフォルト適用」方式に変更済み。`reducesCapacity` (boolean) 相当として `isHoliday` も「初回選択時のみデフォルト適用」にするか、boolean フィールドは常に追従するかの設計判断が必要。
 
 ## バグ: フィルタープリセットに monthlyEmployeeSearch が含まれない
 

--- a/components/duty-assignments/duty-assignment-form.tsx
+++ b/components/duty-assignments/duty-assignment-form.tsx
@@ -117,15 +117,24 @@ export function DutyAssignmentForm({
   }
 
   function handleDutyTypeChange(value: string) {
+    const isFirstSelection = selectedDutyTypeId === ""
     setSelectedDutyTypeId(value)
     const dt = dutyTypes.find((d) => d.id.toString() === value)
     if (dt) {
-      setReducesCapacity(dt.defaultReducesCapacity)
-      setStartTime(dt.defaultStartTime ?? "")
-      setEndTime(dt.defaultEndTime ?? "")
-      setNote(dt.defaultNote ?? "")
-      if (!isEdit) {
+      if (isFirstSelection) {
+        setReducesCapacity(dt.defaultReducesCapacity)
+      }
+      if (title.trim() === "") {
         setTitle(dt.defaultTitle ?? "")
+      }
+      if (startTime.trim() === "") {
+        setStartTime(dt.defaultStartTime ?? "")
+      }
+      if (endTime.trim() === "") {
+        setEndTime(dt.defaultEndTime ?? "")
+      }
+      if (note.trim() === "") {
+        setNote(dt.defaultNote ?? "")
       }
     }
   }

--- a/tests/components/duty-assignment-form.test.tsx
+++ b/tests/components/duty-assignment-form.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeAll } from "vitest"
+
+// Radix Select が happy-dom で参照する pointer capture 系 API の軽量 polyfill
+beforeAll(() => {
+  if (!(Element.prototype as unknown as { hasPointerCapture?: unknown }).hasPointerCapture) {
+    Object.defineProperty(Element.prototype, "hasPointerCapture", {
+      value: () => false,
+      configurable: true,
+    })
+  }
+  if (!(Element.prototype as unknown as { releasePointerCapture?: unknown }).releasePointerCapture) {
+    Object.defineProperty(Element.prototype, "releasePointerCapture", {
+      value: () => {},
+      configurable: true,
+    })
+  }
+  if (!(Element.prototype as unknown as { scrollIntoView?: unknown }).scrollIntoView) {
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      value: () => {},
+      configurable: true,
+    })
+  }
+})
+
+// Server Actions をモック（実行させない）
+vi.mock("@/lib/actions/duty-assignment-actions", () => ({
+  createDutyAssignment: vi.fn().mockResolvedValue({}),
+  updateDutyAssignment: vi.fn().mockResolvedValue({}),
+  deleteDutyAssignment: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+import { DutyAssignmentForm } from "@/components/duty-assignments/duty-assignment-form"
+
+const EMPLOYEES = [{ id: "emp-1", name: "テスト太郎" }]
+
+const DUTY_TYPES = [
+  {
+    id: 1,
+    name: "朝番",
+    defaultReducesCapacity: true,
+    defaultStartTime: "09:00",
+    defaultEndTime: "17:00",
+    defaultNote: "朝番デフォルト備考",
+    defaultTitle: "朝番デフォルトタイトル",
+  },
+  {
+    id: 2,
+    name: "遅番",
+    defaultReducesCapacity: false,
+    defaultStartTime: "13:00",
+    defaultEndTime: "21:00",
+    defaultNote: "遅番デフォルト備考",
+    defaultTitle: "遅番デフォルトタイトル",
+  },
+  {
+    id: 3,
+    name: "空デフォルト",
+    defaultReducesCapacity: true,
+    defaultStartTime: null,
+    defaultEndTime: null,
+    defaultNote: null,
+    defaultTitle: null,
+  },
+]
+
+function renderForm() {
+  return render(
+    <DutyAssignmentForm
+      employees={EMPLOYEES}
+      dutyTypes={DUTY_TYPES}
+      open={true}
+      onOpenChange={() => {}}
+    />
+  )
+}
+
+// Radix Select の「業務種別」トリガーはフォーム内 combobox のうち2番目
+// (1番目は従業員 Popover ボタン)
+async function selectDutyType(
+  user: ReturnType<typeof userEvent.setup>,
+  optionName: string
+) {
+  const comboboxes = screen.getAllByRole("combobox")
+  const dutyTypeTrigger = comboboxes[1]
+  await user.click(dutyTypeTrigger)
+  const option = await screen.findByRole("option", { name: optionName })
+  await user.click(option)
+}
+
+describe("DutyAssignmentForm - 業務種別選択時のフィールド保護", () => {
+  it("初回選択: 空のフィールドにデフォルト値が反映される", async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    await selectDutyType(user, "朝番")
+
+    expect(screen.getByLabelText("タイトル")).toHaveValue("朝番デフォルトタイトル")
+    expect(screen.getByLabelText(/開始時刻/)).toHaveValue("09:00")
+    expect(screen.getByLabelText(/終了時刻/)).toHaveValue("17:00")
+    expect(screen.getByLabelText("備考")).toHaveValue("朝番デフォルト備考")
+  })
+
+  it("【リグレッション】タイトル入力済み → 業務種別選択でタイトル保持", async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    const titleInput = screen.getByLabelText("タイトル")
+    await user.type(titleInput, "ユーザー入力タイトル")
+
+    await selectDutyType(user, "朝番")
+
+    expect(titleInput).toHaveValue("ユーザー入力タイトル")
+    // 他の空フィールドにはデフォルトが入る
+    expect(screen.getByLabelText(/開始時刻/)).toHaveValue("09:00")
+  })
+
+  it("【リグレッション】開始/終了時刻入力済み → 業務種別選択で時刻保持", async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    const startInput = screen.getByLabelText(/開始時刻/) as HTMLInputElement
+    const endInput = screen.getByLabelText(/終了時刻/) as HTMLInputElement
+    await user.type(startInput, "10:30")
+    await user.type(endInput, "18:30")
+
+    await selectDutyType(user, "朝番")
+
+    expect(startInput).toHaveValue("10:30")
+    expect(endInput).toHaveValue("18:30")
+    // 空だったタイトル・備考にはデフォルトが入る
+    expect(screen.getByLabelText("タイトル")).toHaveValue("朝番デフォルトタイトル")
+  })
+
+  it("【リグレッション】備考入力済み → 業務種別選択で備考保持", async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    const noteInput = screen.getByLabelText("備考")
+    await user.type(noteInput, "ユーザー備考")
+
+    await selectDutyType(user, "朝番")
+
+    expect(noteInput).toHaveValue("ユーザー備考")
+  })
+
+  it("reducesCapacity は初回選択時のみデフォルト適用、以降はユーザー設定を保持", async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    const checkbox = screen.getByLabelText(/対応可能人員から控除する/) as HTMLButtonElement
+
+    // 初期値は true
+    expect(checkbox).toHaveAttribute("data-state", "checked")
+
+    // 初回: 朝番 (defaultReducesCapacity: true) → checked のまま
+    await selectDutyType(user, "朝番")
+    expect(checkbox).toHaveAttribute("data-state", "checked")
+
+    // ユーザーが OFF
+    await user.click(checkbox)
+    expect(checkbox).toHaveAttribute("data-state", "unchecked")
+
+    // 2回目: 遅番 (defaultReducesCapacity: false) → ユーザー設定(OFF)を保持
+    await selectDutyType(user, "遅番")
+    expect(checkbox).toHaveAttribute("data-state", "unchecked")
+  })
+
+  it("デフォルト値が null の業務種別 → フィールドは空のまま", async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    await selectDutyType(user, "空デフォルト")
+
+    expect(screen.getByLabelText("タイトル")).toHaveValue("")
+    expect(screen.getByLabelText(/開始時刻/)).toHaveValue("")
+    expect(screen.getByLabelText(/終了時刻/)).toHaveValue("")
+    expect(screen.getByLabelText("備考")).toHaveValue("")
+  })
+
+  it("業務種別を切り替え: 入力済みフィールドは保持、空フィールドのみデフォルト適用", async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    // 1回目: 朝番 → 全フィールドに朝番デフォルト
+    await selectDutyType(user, "朝番")
+    expect(screen.getByLabelText("タイトル")).toHaveValue("朝番デフォルトタイトル")
+
+    // タイトルのみクリア → 遅番に切替
+    const titleInput = screen.getByLabelText("タイトル")
+    await user.clear(titleInput)
+    await selectDutyType(user, "遅番")
+
+    // タイトルは空だったので遅番デフォルトが入る
+    expect(titleInput).toHaveValue("遅番デフォルトタイトル")
+    // 時刻・備考は朝番の値が保持される
+    expect(screen.getByLabelText(/開始時刻/)).toHaveValue("09:00")
+    expect(screen.getByLabelText(/終了時刻/)).toHaveValue("17:00")
+    expect(screen.getByLabelText("備考")).toHaveValue("朝番デフォルト備考")
+  })
+
+  it("半角スペースのみの入力は空扱い (.trim() 判定) でデフォルトが適用される", async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    const titleInput = screen.getByLabelText("タイトル")
+    await user.type(titleInput, "   ")
+
+    await selectDutyType(user, "朝番")
+
+    expect(titleInput).toHaveValue("朝番デフォルトタイトル")
+  })
+})


### PR DESCRIPTION
## Summary
業務割当作成/編集ダイアログで、ユーザーがタイトル・時刻・備考を入力した後に業務種別を選択すると、入力済みの値が業務種別のデフォルト値で上書きされるバグを修正しました。

### 変更内容
- `handleDutyTypeChange` を「空フィールドのみデフォルト適用」方式に変更
  - `title` / `startTime` / `endTime` / `note` — `.trim() === ""` で空判定、入力済みなら保持
  - `reducesCapacity` — 初回業務種別選択時のみデフォルト適用、以降はユーザー設定（チェックON/OFF）を保持
  - 編集モード判定 (`isEdit`) を削除し、新規/編集とも同じロジックに統一

### 不変条件
- 空のフィールドに対しては従来通り業務種別のデフォルト値が自動入力される
- 業務種別のデフォルト値が `null` の場合、フィールドは空のまま変更されない

## Test Coverage
新規テストファイル `tests/components/duty-assignment-form.test.tsx` に 8 ケース追加（全 PASS）:

1. 初回選択: 空のフィールドにデフォルト値が反映される
2. **【リグレッション】** タイトル入力済み → 業務種別選択でタイトル保持
3. **【リグレッション】** 開始/終了時刻入力済み → 業務種別選択で時刻保持
4. **【リグレッション】** 備考入力済み → 業務種別選択で備考保持
5. `reducesCapacity` は初回選択時のみデフォルト適用、以降はユーザー設定を保持
6. デフォルト値が null の業務種別 → フィールドは空のまま
7. 業務種別を切り替え: 入力済みフィールドは保持、空フィールドのみデフォルト適用
8. 半角スペースのみの入力は空扱い (`.trim()` 判定) でデフォルトが適用される

happy-dom で Radix Select を扱うため `hasPointerCapture` / `releasePointerCapture` / `scrollIntoView` の軽量 polyfill を test ファイル内に追加。

## Pre-Landing Review
- TypeScript typecheck: クリーン
- ESLint: 新規・変更ファイルに問題なし（既存ファイルの pre-existing エラーは対象外）
- リグレッションテスト 3 件を必須追加（Completeness: 10/10）

## TODOS
- ❌ 削除: 「UX改善: 編集時のDutyType変更でdefault値が上書きされる問題」（今回の PR で解決）
- ➕ 追加: 「UX改善: シフトフォームのシフトコード変更でdefault値が上書きされる問題」（`components/shifts/shift-form.tsx:195-226` に同種のバグあり、別 PR で対応）

## Test plan
- [x] Vitest: 8/8 tests passing
- [x] TypeScript typecheck passes
- [x] ESLint: no new issues introduced
- [ ] 実機動作確認: タイトル入力 → 業務種別選択でタイトルが保持されること
- [ ] 実機動作確認: 時刻入力 → 業務種別選択で時刻が保持されること
- [ ] 実機動作確認: \`reducesCapacity\` チェック OFF 後、業務種別切替で OFF のまま維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)