### PR TITLE
fix: (内SV)カウント等のroleType位置依存を定数化

### DIFF
--- a/app/(main)/duty-assignments/page.tsx
+++ b/app/(main)/duty-assignments/page.tsx
@@ -18,6 +18,7 @@ import { getGroups } from "@/lib/db/groups"
 import { getFunctionRoles } from "@/lib/db/roles"
 import { getTodayJST } from "@/lib/date-utils"
 import { SHIFT_CODE_MAP, getColorClasses, type ShiftCodeInfo } from "@/lib/constants"
+import { DISTINCT_ROLE_TYPES } from "@/lib/constants/role-types"
 import { auth } from "@/auth"
 import type { DashboardOverviewFilter } from "@/types"
 import type { ShiftCodeMap } from "@/types/duties"
@@ -120,11 +121,8 @@ export default async function DutyAssignmentsPage({ searchParams }: Props) {
       getLatestShiftHistoryEntries(dailyYear, dailyMonth),
     ])
 
-    // roleTypes 決定（dashboard と同じロジック）
-    const distinctRoleTypes = (() => {
-      const types = [...new Set(roles.map((r) => r.roleType))].sort()
-      return [types[0] ?? "権限", types[1] ?? "職務"] as const
-    })()
+    // roleTypes[0] = SV (監督系)、roleTypes[1] = 業務系で固定 (lib/constants/role-types.ts)
+    const distinctRoleTypes = DISTINCT_ROLE_TYPES
 
     return (
       <>
@@ -271,7 +269,7 @@ export default async function DutyAssignmentsPage({ searchParams }: Props) {
           dailyOvernightShifts={[]}
           dailyDuties={[]}
           dailyFilterOptions={{ employees: [], groups: [], shiftCodes: [], hasUnassigned: false, supervisorRoleNames: [], businessRoleNames: [] }}
-          dailyDistinctRoleTypes={["権限", "職務"] as const}
+          dailyDistinctRoleTypes={DISTINCT_ROLE_TYPES}
           dailyShiftCodes={[]}
           dailyShiftIdsWithHistory={[]}
           dailyShiftLatestHistory={{}}

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -19,6 +19,7 @@ import { getActiveShiftCodes } from "@/lib/db/shift-codes"
 import { getShiftIdsWithHistory, getLatestShiftHistoryEntries } from "@/lib/db/shifts"
 import { getTodayJST } from "@/lib/date-utils"
 import { format } from "date-fns"
+import { DISTINCT_ROLE_TYPES } from "@/lib/constants/role-types"
 import type { DashboardOverviewFilter } from "@/types"
 
 function parseIds(value: string | string[] | undefined): number[] {
@@ -79,12 +80,8 @@ export default async function DashboardPage({ searchParams }: Props) {
       getPreviousDayOvernightDutyAssignments(todayJST),
     ])
 
-  // ロールタイプからカラム名を決定（shift-daily-viewと同じロジック）
-  // ASC ソートで roleTypes[0]=監督系(権限), roleTypes[1]=業務系(職務)
-  const distinctRoleTypes = (() => {
-    const types = [...new Set(roles.map((r) => r.roleType))].sort()
-    return [types[0] ?? "権限", types[1] ?? "職務"] as const
-  })()
+  // roleTypes[0] = SV (監督系)、roleTypes[1] = 業務系で固定 (lib/constants/role-types.ts)
+  const distinctRoleTypes = DISTINCT_ROLE_TYPES
 
   return (
     <>

--- a/components/shifts/shift-daily-view.tsx
+++ b/components/shifts/shift-daily-view.tsx
@@ -21,6 +21,7 @@ import { ShiftBadge } from "@/components/shifts/shift-badge"
 import { ShiftForm } from "@/components/shifts/shift-form"
 import { ShiftDetailDialog } from "@/components/shifts/shift-detail-dialog"
 import type { ShiftCodeInfo } from "@/lib/constants"
+import { DISTINCT_ROLE_TYPES } from "@/lib/constants/role-types"
 import type { LatestShiftHistory } from "@/lib/db/shifts"
 import { ColumnFilterPopover } from "@/components/common/filters/column-filter-popover"
 import { EmployeeCheckboxFilter } from "@/components/common/filters/employee-checkbox-filter"
@@ -283,12 +284,8 @@ export function ShiftDailyView({
     setBusinessPopoverOpen(false)
   }, [setParams])
 
-  // --- Distinct role types for dynamic column headers ---
-  // ASC ソートで roleTypes[0]=監督系(権限), roleTypes[1]=業務系(職務)
-  const distinctRoleTypes = useMemo(() => {
-    const types = [...new Set(roles.map((r) => r.roleType))].sort()
-    return [types[0] ?? "権限", types[1] ?? "職務"] as const
-  }, [roles])
+  // roleTypes[0] = SV (監督系)、roleTypes[1] = 業務系で固定 (lib/constants/role-types.ts)
+  const distinctRoleTypes = DISTINCT_ROLE_TYPES
 
   // --- Filter tags ---
   const filterTags = useMemo<FilterTag[]>(() => {

--- a/lib/constants/role-types.ts
+++ b/lib/constants/role-types.ts
@@ -1,0 +1,21 @@
+/**
+ * function_roles.role_type の取り得る値。
+ *
+ * 以前は `[...types].sort()` による位置依存で「配列[0]=SV、配列[1]=業務」と
+ * 扱っていたが、日本語のコードポイント比較では「業務」(U+696D) < 「監督」(U+76E3)
+ * であるため ASC ソートで `[0]=業務` となり、SV 判定・UI ラベル・フィルタが
+ * 全て逆転するバグが発生していた (CHANGELOG v0.2.13.3 の DESC→ASC 移行で silent に混入)。
+ *
+ * 位置に頼らず、どのロール種別かは必ずこの定数と比較する。
+ */
+export const SUPERVISOR_ROLE_TYPE = "監督"
+export const BUSINESS_ROLE_TYPE = "業務"
+
+/**
+ * 既存コードで配列インデックスに依存している箇所 (カラムラベル・フィルタ・CSV列見出し等)
+ * の後方互換のため、`readonly [string, string]` タプルを維持する。
+ * インデックスの意味は `[0] = SV、[1] = 業務` と固定。
+ */
+export const DISTINCT_ROLE_TYPES = [SUPERVISOR_ROLE_TYPE, BUSINESS_ROLE_TYPE] as const
+
+export type DistinctRoleTypes = typeof DISTINCT_ROLE_TYPES

--- a/lib/db/dashboard.ts
+++ b/lib/db/dashboard.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma"
 import { getTodayJST } from "@/lib/date-utils"
 import { getTimeHHMM } from "@/lib/capacity-utils"
+import { DISTINCT_ROLE_TYPES } from "@/lib/constants/role-types"
 import type { DashboardOverviewFilter, DashboardFilterOptions } from "@/types"
 
 /** EmployeeGroup 用 Prisma where 条件（startDate nullable） */
@@ -24,20 +25,12 @@ function currentRoleDateWhere(today: Date) {
 }
 
 /**
- * DB から distinct role_type を取得して動的にカラムマッピング（getShiftsForDaily と同じロジック）
- * roleTypes[0] = 監督系 (権限), roleTypes[1] = 業務系 (職務)
- * ASC ソートにより roleType の昇順で取得（権限 < 職務）
+ * roleTypes[0] = SV (監督系)、roleTypes[1] = 業務系で固定 (lib/constants/role-types.ts)。
+ * 以前は `orderBy: { roleType: "asc" }` でDBから動的に取得していたが、日本語
+ * "業務"/"監督" のASCソートで[0]=業務 になりSV判定が逆転するバグがあった。
  */
 async function getRoleTypes(): Promise<[string, string]> {
-  const distinctTypes = await prisma.functionRole.findMany({
-    select: { roleType: true },
-    distinct: ["roleType"],
-    orderBy: { roleType: "asc" },
-  })
-  return [
-    distinctTypes[0]?.roleType ?? "権限",
-    distinctTypes[1]?.roleType ?? "職務",
-  ]
+  return [DISTINCT_ROLE_TYPES[0], DISTINCT_ROLE_TYPES[1]]
 }
 
 /**

--- a/lib/db/shifts.ts
+++ b/lib/db/shifts.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@/app/generated/prisma/client"
 import type { ShiftFilterParams, ShiftDailyFilterParams, ShiftDailyRow, PaginatedResult, ShiftDailySortField, SortOrder } from "@/types"
 import type { ShiftCalendarData, ShiftCalendarPaginatedResult, ShiftDailyPaginatedResult, DailyFilterOptions } from "@/types/shifts"
 import { toDateString, getTodayJST } from "@/lib/date-utils"
+import { DISTINCT_ROLE_TYPES } from "@/lib/constants/role-types"
 
 /** EmployeeGroup 用 Prisma where 条件（startDate nullable） */
 function currentGroupDateWhere(today: Date) {
@@ -509,17 +510,8 @@ export async function getShiftsForDaily(
   const cursor = options.cursor ?? 0
   const pageSize = options.pageSize ?? DEFAULT_DAILY_PAGE_SIZE
 
-  // DB から distinct role_type を取得して動的にカラムマッピング
-  // ASC ソートにより roleTypes[0]=監督系(権限), roleTypes[1]=業務系(職務)
-  const distinctTypes = await prisma.functionRole.findMany({
-    select: { roleType: true },
-    distinct: ["roleType"],
-    orderBy: { roleType: "asc" },
-  })
-  const roleTypes: [string, string] = [
-    distinctTypes[0]?.roleType ?? "権限",
-    distinctTypes[1]?.roleType ?? "職務",
-  ]
+  // roleTypes[0] = SV (監督系)、roleTypes[1] = 業務系で固定 (lib/constants/role-types.ts)
+  const roleTypes: [string, string] = [DISTINCT_ROLE_TYPES[0], DISTINCT_ROLE_TYPES[1]]
 
   // Raw SQL では文字列 + ::date キャストで日付比較（Date オブジェクトは型不一致になるため）
   const dateStr = filter.date // "YYYY-MM-DD" 形式
@@ -704,16 +696,8 @@ export async function getDailyFilterOptions(
 ): Promise<DailyFilterOptions> {
   const dateStr = filter.date
 
-  // roleTypes を取得（ASC: roleTypes[0]=監督系(権限), roleTypes[1]=業務系(職務)）
-  const distinctTypes = await prisma.functionRole.findMany({
-    select: { roleType: true },
-    distinct: ["roleType"],
-    orderBy: { roleType: "asc" },
-  })
-  const roleTypes: [string, string] = [
-    distinctTypes[0]?.roleType ?? "権限",
-    distinctTypes[1]?.roleType ?? "職務",
-  ]
+  // roleTypes[0] = SV (監督系)、roleTypes[1] = 業務系で固定 (lib/constants/role-types.ts)
+  const roleTypes: [string, string] = [DISTINCT_ROLE_TYPES[0], DISTINCT_ROLE_TYPES[1]]
 
   // クエリを並列実行
   const [employeeRows, groupRows, unassignedRows, shiftCodeRows, supervisorRoleRows, businessRoleRows] = await Promise.all([

--- a/tests/db/dashboard.test.ts
+++ b/tests/db/dashboard.test.ts
@@ -164,7 +164,7 @@ describe("Dashboard DB Queries - 日付範囲フィルタリング", () => {
   describe("getDailyOverview - ロールの日付フィルタ", () => {
     it("startDate <= today かつ endDate が null のロールは表示される", async () => {
       const role = await prisma.functionRole.create({
-        data: { roleCode: "SV", roleName: "SV", roleType: "権限" },
+        data: { roleCode: "SV", roleName: "SV", roleType: "監督" },
       })
       const emp = await prisma.employee.create({ data: { name: "田中太郎" } })
       await prisma.employeeFunctionRole.create({
@@ -186,7 +186,7 @@ describe("Dashboard DB Queries - 日付範囲フィルタリング", () => {
 
     it("startDate が未来のロールは表示されない", async () => {
       const role = await prisma.functionRole.create({
-        data: { roleCode: "SV", roleName: "SV", roleType: "権限" },
+        data: { roleCode: "SV", roleName: "SV", roleType: "監督" },
       })
       const emp = await prisma.employee.create({ data: { name: "田中太郎" } })
       await prisma.employeeFunctionRole.create({
@@ -207,7 +207,7 @@ describe("Dashboard DB Queries - 日付範囲フィルタリング", () => {
 
     it("endDate が過去のロールは表示されない", async () => {
       const role = await prisma.functionRole.create({
-        data: { roleCode: "SV", roleName: "SV", roleType: "権限" },
+        data: { roleCode: "SV", roleName: "SV", roleType: "監督" },
       })
       const emp = await prisma.employee.create({ data: { name: "田中太郎" } })
       await prisma.employeeFunctionRole.create({
@@ -228,7 +228,7 @@ describe("Dashboard DB Queries - 日付範囲フィルタリング", () => {
 
     it("endDate が未来のロールは表示される", async () => {
       const role = await prisma.functionRole.create({
-        data: { roleCode: "SV", roleName: "SV", roleType: "権限" },
+        data: { roleCode: "SV", roleName: "SV", roleType: "監督" },
       })
       const emp = await prisma.employee.create({ data: { name: "田中太郎" } })
       await prisma.employeeFunctionRole.create({
@@ -249,7 +249,7 @@ describe("Dashboard DB Queries - 日付範囲フィルタリング", () => {
 
     it("startDate が null のロール（旧データ）は表示される", async () => {
       const role = await prisma.functionRole.create({
-        data: { roleCode: "SV", roleName: "SV", roleType: "権限" },
+        data: { roleCode: "SV", roleName: "SV", roleType: "監督" },
       })
       const emp = await prisma.employee.create({ data: { name: "田中太郎" } })
       await prisma.employeeFunctionRole.create({
@@ -471,7 +471,7 @@ describe("Dashboard DB Queries - 日付範囲フィルタリング", () => {
 
     it("SVフィルター適用時、現在SVロールがない夜勤従業員は除外される", async () => {
       const svRole = await prisma.functionRole.create({
-        data: { roleCode: "SV", roleName: "SV", roleType: "権限" },
+        data: { roleCode: "SV", roleName: "SV", roleType: "監督" },
       })
 
       const svEmp = await prisma.employee.create({ data: { name: "SV夜勤" } })


### PR DESCRIPTION
## Summary

タイムラインビューの「(内SV)」カウントがDBの本物SV(3件)ではなく業務ロール保有者(65件)をカウントしていた silent bug を修正。同じ前提に依存する UI ラベル・フィルタ・カラム表示・CSVエクスポートも一斉に正しくなる。

## Root Cause

`distinctRoleTypes = [...new Set(roles.map(r => r.roleType))].sort()` で生成した配列の `[0]` を SV 用に使っていたが、日本語で `"業務"` (U+696D) < `"監督"` (U+76E3) の Unicode 比較により ASC ソートで `[0] = "業務"` になっていた。

CHANGELOG v0.2.13.3 の「DESC→ASC 統一」修正が、DB内の実 roleType 値を確認せず全サイトに展開されたのが混入経路。

**検証**:
- バグ時: 65人 (業務ロール保有者) が (内SV) にカウント、本物のSV 3人は除外
- 修正後: 3人 (本物のSV) のみカウント

## Fix

`lib/constants/role-types.ts` に `SUPERVISOR_ROLE_TYPE = "監督"` / `BUSINESS_ROLE_TYPE = "業務"` を定数化し、位置依存の生成ロジックを削除。

変更ファイル:
- **新規**: `lib/constants/role-types.ts`
- **変更**: `app/(main)/page.tsx`, `app/(main)/duty-assignments/page.tsx`, `components/shifts/shift-daily-view.tsx`, `lib/db/dashboard.ts`, `lib/db/shifts.ts`
- **テスト修正**: `tests/db/dashboard.test.ts` の `roleType: "権限"` → `"監督"` (DB実データに整合)

## Test plan

- [x] `npx tsc --noEmit` 通過
- [x] Vitest 全 583 テスト pass
- [x] DB実データで検証: `[0] = "監督"`, SV数 = 3 (本物)、業務数 = 65
- [ ] ステージングでダッシュボードタイムラインの (内SV) が実際のSV人数と一致するか目視確認
- [ ] 業務管理日次・シフト日次ビューの SV/業務フィルタとカラム表示が意図通りか目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)