### PR TITLE
test: Server Action のエラー/バリデーション分岐をカバー (Tier 3)

### DIFF
--- a/tests/actions/duty-type-actions.test.ts
+++ b/tests/actions/duty-type-actions.test.ts
@@ -14,7 +14,37 @@ const {
   createDutyType,
   updateDutyType,
   deleteDutyType,
+  importDutyTypes,
 } = await import("@/lib/actions/duty-type-actions")
+
+function makeImportRow(
+  overrides: Partial<{
+    rowIndex: number
+    name: string
+    color: string | null
+    isActive: boolean
+    sortOrder: number
+    defaultReducesCapacity: boolean
+    defaultStartTime: string | null
+    defaultEndTime: string | null
+    defaultTitle: string | null
+    defaultNote: string | null
+  }> = {}
+) {
+  return {
+    rowIndex: 1,
+    name: "電話対応",
+    color: null,
+    isActive: true,
+    sortOrder: 0,
+    defaultReducesCapacity: true,
+    defaultStartTime: null,
+    defaultEndTime: null,
+    defaultTitle: null,
+    defaultNote: null,
+    ...overrides,
+  }
+}
 
 function makeFormData(data: Record<string, string>): FormData {
   const fd = new FormData()
@@ -223,6 +253,97 @@ describe("DutyType Actions", () => {
 
       const deleted = await prisma.dutyType.findUnique({ where: { id: dt.id } })
       expect(deleted).toBeNull()
+    })
+
+    it("使用中（割当あり）の業務種別削除はエラーを返す", async () => {
+      const dt = await prisma.dutyType.create({ data: { name: "使用中種別" } })
+      const emp = await prisma.employee.create({ data: { name: "田中太郎" } })
+      await prisma.dutyAssignment.create({
+        data: {
+          dutyTypeId: dt.id,
+          employeeId: emp.id,
+          dutyDate: new Date("2026-01-15"),
+          startTime: new Date("1970-01-01T09:00:00Z"),
+          endTime: new Date("1970-01-01T17:00:00Z"),
+        },
+      })
+
+      const result = await deleteDutyType(dt.id)
+
+      expect(result).toHaveProperty("error")
+      // 削除は失敗し、レコードは残っている
+      const still = await prisma.dutyType.findUnique({ where: { id: dt.id } })
+      expect(still).not.toBeNull()
+    })
+  })
+
+  describe("importDutyTypes", () => {
+    it("新規行を作成し created にカウントする", async () => {
+      const result = await importDutyTypes([
+        makeImportRow({ rowIndex: 1, name: "電話対応" }),
+        makeImportRow({ rowIndex: 2, name: "会議", defaultStartTime: "09:00", defaultEndTime: "17:00" }),
+      ])
+
+      expect(result.created).toBe(2)
+      expect(result.updated).toBe(0)
+      expect(result.errors).toEqual([])
+
+      const meeting = await prisma.dutyType.findFirst({ where: { name: "会議" } })
+      expect(meeting!.defaultStartTime).toBe("09:00")
+      expect(meeting!.defaultEndTime).toBe("17:00")
+    })
+
+    it("同名の既存行は更新し updated にカウントする", async () => {
+      await prisma.dutyType.create({
+        data: { name: "電話対応", sortOrder: 0, defaultNote: "旧メモ" },
+      })
+
+      const result = await importDutyTypes([
+        makeImportRow({ name: "電話対応", sortOrder: 5, defaultNote: "新メモ" }),
+      ])
+
+      expect(result.created).toBe(0)
+      expect(result.updated).toBe(1)
+
+      const dt = await prisma.dutyType.findFirst({ where: { name: "電話対応" } })
+      expect(dt!.sortOrder).toBe(5)
+      expect(dt!.defaultNote).toBe("新メモ")
+    })
+
+    it("新規と更新が混在しても正しく集計する", async () => {
+      await prisma.dutyType.create({ data: { name: "既存種別" } })
+
+      const result = await importDutyTypes([
+        makeImportRow({ rowIndex: 1, name: "既存種別" }),
+        makeImportRow({ rowIndex: 2, name: "新規種別" }),
+      ])
+
+      expect(result.created).toBe(1)
+      expect(result.updated).toBe(1)
+      expect(result.errors).toEqual([])
+    })
+
+    it("保存失敗した行は errors に rowIndex 付きで記録し他の行は処理を続行する", async () => {
+      // name は VarChar(50)。51 文字超で DB エラーを誘発する
+      const tooLong = "あ".repeat(60)
+
+      const result = await importDutyTypes([
+        makeImportRow({ rowIndex: 1, name: "正常種別" }),
+        makeImportRow({ rowIndex: 2, name: tooLong }),
+      ])
+
+      expect(result.created).toBe(1)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].rowIndex).toBe(2)
+
+      // 正常な行はコミットされている
+      const ok = await prisma.dutyType.findFirst({ where: { name: "正常種別" } })
+      expect(ok).not.toBeNull()
+    })
+
+    it("空配列なら全カウント 0", async () => {
+      const result = await importDutyTypes([])
+      expect(result).toEqual({ created: 0, updated: 0, errors: [] })
     })
   })
 })

--- a/tests/actions/employee-history-actions.test.ts
+++ b/tests/actions/employee-history-actions.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { prisma } from "../helpers/prisma"
+import { cleanupDatabase } from "../helpers/cleanup"
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+vi.mock("@/lib/prisma", async () => {
+  return { prisma: (await import("../helpers/prisma")).prisma }
+})
+vi.mock("@/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: "1", name: "admin" } }),
+}))
+
+const {
+  updateGroupHistory,
+  deleteGroupHistory,
+  updateRoleHistory,
+  deleteRoleHistory,
+  updatePositionHistory,
+  deletePositionHistory,
+} = await import("@/lib/actions/employee-actions")
+
+async function createEmployee(name = "田中太郎") {
+  return prisma.employee.create({ data: { name } })
+}
+
+describe("Employee history edit/delete actions", () => {
+  beforeEach(async () => {
+    await cleanupDatabase()
+  })
+
+  describe("updateGroupHistory", () => {
+    it("開始日・終了日を更新できる", async () => {
+      const emp = await createEmployee()
+      const group = await prisma.group.create({ data: { name: "開発部" } })
+      const hist = await prisma.employeeGroupHistory.create({
+        data: {
+          employeeId: emp.id,
+          groupId: group.id,
+          startDate: new Date("2026-01-01"),
+          endDate: null,
+          changeType: "CREATE",
+          version: 1,
+        },
+      })
+
+      const result = await updateGroupHistory(hist.id, {
+        startDate: "2026-02-01",
+        endDate: "2026-03-31",
+      })
+
+      expect(result).toEqual({ success: true })
+      const updated = await prisma.employeeGroupHistory.findUnique({ where: { id: hist.id } })
+      expect(updated!.startDate?.toISOString().slice(0, 10)).toBe("2026-02-01")
+      expect(updated!.endDate?.toISOString().slice(0, 10)).toBe("2026-03-31")
+    })
+
+    it("startDate を空文字→null にクリアできる", async () => {
+      const emp = await createEmployee()
+      const hist = await prisma.employeeGroupHistory.create({
+        data: {
+          employeeId: emp.id,
+          startDate: new Date("2026-01-01"),
+          changeType: "CREATE",
+          version: 1,
+        },
+      })
+
+      const result = await updateGroupHistory(hist.id, { startDate: null })
+
+      expect(result).toEqual({ success: true })
+      const updated = await prisma.employeeGroupHistory.findUnique({ where: { id: hist.id } })
+      expect(updated!.startDate).toBeNull()
+    })
+
+    it("不正な groupId はバリデーションエラー", async () => {
+      const result = await updateGroupHistory(1, { groupId: -5 })
+      expect(result).toHaveProperty("error")
+    })
+
+    it("存在しない id はエラーを返す", async () => {
+      const result = await updateGroupHistory(999999, { startDate: "2026-01-01" })
+      expect(result).toHaveProperty("error")
+    })
+  })
+
+  describe("deleteGroupHistory", () => {
+    it("所属履歴を削除できる", async () => {
+      const emp = await createEmployee()
+      const hist = await prisma.employeeGroupHistory.create({
+        data: { employeeId: emp.id, changeType: "CREATE", version: 1 },
+      })
+
+      const result = await deleteGroupHistory(hist.id)
+
+      expect(result).toEqual({ success: true })
+      expect(
+        await prisma.employeeGroupHistory.findUnique({ where: { id: hist.id } })
+      ).toBeNull()
+    })
+
+    it("存在しない id はエラーを返す", async () => {
+      const result = await deleteGroupHistory(999999)
+      expect(result).toHaveProperty("error")
+    })
+  })
+
+  describe("updateRoleHistory", () => {
+    it("roleType・isPrimary・期間を更新できる", async () => {
+      const emp = await createEmployee()
+      const hist = await prisma.employeeFunctionRoleHistory.create({
+        data: {
+          employeeId: emp.id,
+          roleType: "FUNCTION",
+          isPrimary: false,
+          changeType: "CREATE",
+          version: 1,
+        },
+      })
+
+      const result = await updateRoleHistory(hist.id, {
+        roleType: "ADMIN",
+        isPrimary: true,
+        startDate: "2026-04-01",
+      })
+
+      expect(result).toEqual({ success: true })
+      const updated = await prisma.employeeFunctionRoleHistory.findUnique({
+        where: { id: hist.id },
+      })
+      expect(updated!.roleType).toBe("ADMIN")
+      expect(updated!.isPrimary).toBe(true)
+      expect(updated!.startDate?.toISOString().slice(0, 10)).toBe("2026-04-01")
+    })
+
+    it("存在しない id はエラーを返す", async () => {
+      const result = await updateRoleHistory(999999, { roleType: "ADMIN" })
+      expect(result).toHaveProperty("error")
+    })
+  })
+
+  describe("deleteRoleHistory", () => {
+    it("ロール履歴を削除できる", async () => {
+      const emp = await createEmployee()
+      const hist = await prisma.employeeFunctionRoleHistory.create({
+        data: { employeeId: emp.id, changeType: "CREATE", version: 1 },
+      })
+
+      const result = await deleteRoleHistory(hist.id)
+
+      expect(result).toEqual({ success: true })
+      expect(
+        await prisma.employeeFunctionRoleHistory.findUnique({ where: { id: hist.id } })
+      ).toBeNull()
+    })
+
+    it("存在しない id はエラーを返す", async () => {
+      const result = await deleteRoleHistory(999999)
+      expect(result).toHaveProperty("error")
+    })
+  })
+
+  describe("updatePositionHistory", () => {
+    it("positionId・期間を更新できる", async () => {
+      const emp = await createEmployee()
+      const position = await prisma.position.create({
+        data: { positionCode: "KACHO", positionName: "課長" },
+      })
+      const hist = await prisma.employeePositionHistory.create({
+        data: {
+          employeeId: emp.id,
+          startDate: new Date("2026-01-01"),
+          changeType: "CREATE",
+          version: 1,
+        },
+      })
+
+      const result = await updatePositionHistory(hist.id, {
+        positionId: position.id,
+        endDate: "2026-12-31",
+      })
+
+      expect(result).toEqual({ success: true })
+      const updated = await prisma.employeePositionHistory.findUnique({
+        where: { id: hist.id },
+      })
+      expect(updated!.positionId).toBe(position.id)
+      expect(updated!.endDate?.toISOString().slice(0, 10)).toBe("2026-12-31")
+    })
+
+    it("不正な positionId はバリデーションエラー", async () => {
+      const result = await updatePositionHistory(1, { positionId: 0 })
+      expect(result).toHaveProperty("error")
+    })
+
+    it("存在しない id はエラーを返す", async () => {
+      const result = await updatePositionHistory(999999, { endDate: "2026-12-31" })
+      expect(result).toHaveProperty("error")
+    })
+  })
+
+  describe("deletePositionHistory", () => {
+    it("役職履歴を削除できる", async () => {
+      const emp = await createEmployee()
+      const hist = await prisma.employeePositionHistory.create({
+        data: { employeeId: emp.id, changeType: "CREATE", version: 1 },
+      })
+
+      const result = await deletePositionHistory(hist.id)
+
+      expect(result).toEqual({ success: true })
+      expect(
+        await prisma.employeePositionHistory.findUnique({ where: { id: hist.id } })
+      ).toBeNull()
+    })
+
+    it("存在しない id はエラーを返す", async () => {
+      const result = await deletePositionHistory(999999)
+      expect(result).toHaveProperty("error")
+    })
+  })
+})

--- a/tests/actions/import-log-actions.test.ts
+++ b/tests/actions/import-log-actions.test.ts
@@ -11,7 +11,9 @@ vi.mock("@/auth", () => ({
   auth: vi.fn().mockResolvedValue({ user: { id: "1", name: "admin" } }),
 }))
 
-const { recordImportLog } = await import("@/lib/actions/import-log-actions")
+const { recordImportLog, fetchImportLogs } = await import(
+  "@/lib/actions/import-log-actions"
+)
 
 describe("recordImportLog", () => {
   beforeEach(async () => {
@@ -68,5 +70,42 @@ describe("recordImportLog", () => {
     expect("error" in result).toBe(true)
     const count = await prisma.importLog.count()
     expect(count).toBe(0)
+  })
+})
+
+describe("fetchImportLogs", () => {
+  beforeEach(async () => {
+    await cleanupDatabase()
+    vi.mocked(auth).mockResolvedValue({ user: { id: "1", name: "admin" } } as never)
+  })
+
+  it("ページネーション付きで取り込み履歴を返す", async () => {
+    await recordImportLog({ targetType: "shifts", createdCount: 1, updatedCount: 0, errorCount: 0 })
+    await recordImportLog({ targetType: "employees", createdCount: 2, updatedCount: 0, errorCount: 0 })
+
+    const result = await fetchImportLogs({ page: 1, pageSize: 20 })
+
+    expect(result.error).toBeUndefined()
+    expect(result.data.total).toBe(2)
+    expect(result.data.page).toBe(1)
+    expect(result.data.totalPages).toBe(1)
+    expect(result.data.data).toHaveLength(2)
+  })
+
+  it("targetType フィルタを適用できる", async () => {
+    await recordImportLog({ targetType: "shifts", createdCount: 1, updatedCount: 0, errorCount: 0 })
+    await recordImportLog({ targetType: "employees", createdCount: 2, updatedCount: 0, errorCount: 0 })
+
+    const result = await fetchImportLogs({ page: 1, pageSize: 20 }, { targetType: "shifts" })
+
+    expect(result.data.total).toBe(1)
+    expect(result.data.data.every((l) => l.targetType === "shifts")).toBe(true)
+  })
+
+  it("該当が無ければ空の結果を返す", async () => {
+    const result = await fetchImportLogs({ page: 1, pageSize: 20 })
+
+    expect(result.data.total).toBe(0)
+    expect(result.data.data).toEqual([])
   })
 })

--- a/tests/actions/shift-actions.test.ts
+++ b/tests/actions/shift-actions.test.ts
@@ -17,6 +17,7 @@ const {
   deleteShift,
   bulkUpdateShifts,
   restoreShiftVersion,
+  fetchShiftVersions,
 } = await import("@/lib/actions/shift-actions")
 
 describe("Shift Actions", () => {
@@ -368,6 +369,34 @@ describe("Shift Actions", () => {
         where: { id: history.id },
       })
       expect(updatedHistory!.note).toBeNull()
+    })
+  })
+
+  describe("fetchShiftVersions", () => {
+    it("シフトの変更履歴を version 降順で返す", async () => {
+      const shift = await prisma.shift.create({
+        data: { employeeId, shiftDate: new Date("2026-01-15"), shiftCode: "A" },
+      })
+      await prisma.shift.update({ where: { id: shift.id }, data: { shiftCode: "B" } }) // v1
+      await prisma.shift.update({ where: { id: shift.id }, data: { shiftCode: "C" } }) // v2
+
+      const result = await fetchShiftVersions(shift.id)
+
+      expect(result.error).toBeUndefined()
+      expect(result.data).toHaveLength(2)
+      // version 降順: 先頭が最新 v2
+      expect(result.data[0].version).toBe(2)
+      expect(result.data[1].version).toBe(1)
+    })
+
+    it("履歴が無ければ空配列を返す", async () => {
+      const shift = await prisma.shift.create({
+        data: { employeeId, shiftDate: new Date("2026-02-01"), shiftCode: "A" },
+      })
+
+      const result = await fetchShiftVersions(shift.id)
+
+      expect(result.data).toEqual([])
     })
   })
 })


### PR DESCRIPTION
## 概要

テスト充実の Tier 3。Server Action の正常系のみ通っていた分岐・未テスト関数をカバーします。Tier 1（純ロジック）・Tier 2（DBクエリ層）は PR #155 で main にマージ済みで、本 PR はその上に乗ります。

## 変更内容

| ファイル | カバレッジ | 追加内容 |
|---|---|---|
| `duty-type-actions.ts` | 51% → ~92% | `importDutyTypes`（新規/更新/混在/行単位エラー隔離/空）、`deleteDutyType` の使用中FKエラー |
| `import-log-actions.ts` | 61% → ~84% | `fetchImportLogs`（ページネーション/フィルタ/空）|
| `employee-actions.ts` | 56% → 61% | 履歴編集/削除6関数（`updateGroupHistory`/`updateRoleHistory`/`updatePositionHistory` の成功+バリデーション+not-found、`delete*History` の成功+not-found）= 606-740 ブロック全体 |
| `shift-actions.ts` | — | `fetchShiftVersions`（version降順 + 空）|

## 検証

- 追加 +26 テスト
- 全 768 テストパス、回帰なし
- ESLint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)