### PR TITLE
chore: .claude/skills/ を gitignore（gstack ツールchurn 除外）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,9 @@ next-env.d.ts
 # E2E 認証フィクスチャ（storageState。秘匿セッションを含むためコミットしない）
 tests/e2e/.auth/
 .gstack/
-.claude/skills/gstack/
+# gstack/Claude スキル一式はツール管理（アプリ本体と無関係）のため追跡しない。
+# 既に追跡済みのスキルは追跡継続（gitignore は追跡済みファイルには影響しない）。
+.claude/skills/
 .claude/scheduled_tasks.lock
 
 # local sample data (real employee data, never commit)


### PR DESCRIPTION
## Summary
gstack/Claude スキル一式 (`.claude/skills/`) を gitignore 対象にするハウスキーピング。

これまで `.claude/skills/gstack/` のみ除外していたが、gstack のアップグレード時に
`.claude/skills/*` 配下へ新しいスキルディレクトリ（`ship/sections`, `plan-*/sections`,
`spec`, `scrape` 等）が多数追加され、`git status` を未追跡ファイルで汚していた。これらは
ツール管理でありアプリ本体と無関係なため、`.claude/skills/` をまとめて除外する。

## 注意
- gitignore は**既に追跡済みのファイルには影響しない**。リポジトリに既にコミット済みの
  約 35 個のスキルディレクトリは追跡継続する（本 PR では untrack しない）。
- 本 PR の効果は「今後新規に追加される未追跡スキルを git status から消す」こと。

## Test plan
- [x] `git status` から未追跡の `.claude/skills/*` が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
